### PR TITLE
Fix Roamer and Scribe Spawning

### DIFF
--- a/src/guppi.py
+++ b/src/guppi.py
@@ -1856,13 +1856,16 @@ You were asleep for: {time_str}
                     with tempfile.NamedTemporaryFile('w', delete=False) as pf:
                         pf.write(combined_content)
                         final_prompt_file = pf.name
-                    
+
+                    meta_dict = {"action_id": turn_id, "mode": mode}
+
                     cmd = [
                         sys.executable, str(BIN_DIR / "scribe.py"), 
                         "--model", model, 
                         "--prompt-file", final_prompt_file, 
                         "--output-inbox", f"inbox:{self.abe_name}",
-                        "--mode", mode
+                        "--mode", mode,
+                        "--meta", json.dumps(meta_dict)
                     ]
                     await self._spawn_subprocess_exec(turn_id, cmd, tracked=False)
                     result = {"status": "spawned_untracked", "note": "Scribe result will arrive in inbox"}
@@ -2027,7 +2030,8 @@ You were asleep for: {time_str}
         tools = {
             "shell": "Execute local shell command. Args: command",
             "remote_exec": "Execute remote SSH command. Args: host, command",
-            "spawn_scribe": "Spawn tasker process. Args: prompt, prompt_file (optional), model, mode (summarize|vectorize). NOTE: 'vectorize' offloads to GPU queue.",
+            "spawn_scribe": "Spawn a single-shot Scribe. Args: prompt, prompt_file (optional), mode (analyze|summarize|vectorize). GUPPI auto-routes the model. 'analyze' is for deep static analysis, 'summarize' compresses text, 'vectorize' offloads to GPU memory.",
+            "spawn_roamer": "Spawn a multi-turn, read-only Investigator. Args: directive, target_host (optional, default: local). Use to trace logs, map directories, or debug configs without burning your context. Returns a markdown report.",
             "rag_search": "Search vector memory. Args: query",
             "todo_list": "List tasks. Args: filter (due|upcoming|all)",
             "todo_add": "Add task. Args: task, priority, due",

--- a/src/roamer.py
+++ b/src/roamer.py
@@ -49,10 +49,11 @@ class SafeShell:
     ALLOWED_CMDS = [
         "ls", "cat", "grep", "head", "tail", "find", 
         "stat", "df", "du", "whoami", "date", "echo", 
-        "awk", "sed", "cut", "sort", "uniq", "wc", "uptime", "free"
+        "awk", "sed", "cut", "sort", "uniq", "wc", "uptime", "free",
+        "systemctl", "journalctl", "sudo"
     ]
 
-    FORBIDDEN_FLAGS = ["-i", "sudo", "su"]
+    FORBIDDEN_FLAGS = ["-i", "su"]
     
     # Hostnames must not start with '-' to avoid option injection in ssh-like commands.
     HOSTNAME_PATTERN = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_.-]*$")
@@ -87,8 +88,14 @@ class SafeShell:
             if not tokens: return False, "Empty command in pipeline."
                 
             base = tokens[0]
+            # If they use sudo, shift the base command check to the next token
+            if base == "sudo":
+                if len(tokens) < 2:
+                    return False, "Empty sudo command."
+                base = tokens[1]
+                
             if base not in self.ALLOWED_CMDS:
-                return False, f"Command '{base}' is not in the read-only whitelist."
+                return False, f"Command '{base}' in pipeline is not in the read-only whitelist."
 
             if any(f in tokens for f in self.FORBIDDEN_FLAGS):
                 return False, f"Forbidden flag detected in '{base}' segment."
@@ -139,7 +146,10 @@ class RoamerAgent:
         self.shell = SafeShell(target_host)
         self.output_inbox = output_inbox
         self.debug_mode = debug_mode
-        self.model = model or DEFAULT_MODEL
+        # Standardize the model string
+        raw_model = model or DEFAULT_MODEL
+        self.model = raw_model.replace("local/", "") if raw_model.startswith("local/") else raw_model
+        
         
         url = api_url or DEFAULT_API_URL
         self.client = OpenAI(base_url=url, api_key=DEFAULT_API_KEY)
@@ -189,38 +199,71 @@ PROTOCOL:
                     temperature=0.1 # Low temp for precise logic
                 )
                 msg = response.choices[0].message
-                # Normalize assistant message into a plain dict for history so it doesn't crash turn 2
-                assistant_entry = {
-                    "role": msg.role,
-                    "content": msg.content,
-                }
-                if getattr(msg, "tool_calls", None):
-                    assistant_entry["tool_calls"] = [
-                        {
-                            "id": tc.id,
-                            "type": tc.type,
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            }
-                        } for tc in msg.tool_calls
-                    ]
-                self.history.append(assistant_entry)
             except Exception as e:
                 self._report_failure(f"LLM API Failure: {e}")
                 return
 
-            # 2. Check for Tool Calls
-            if msg.tool_calls:
-                for tool_call in msg.tool_calls:
-                    func_name = tool_call.function.name
+            # Normalize assistant message into a plain dict for history
+            assistant_entry = {
+                "role": msg.role,
+                "content": msg.content,
+            }
+            
+            # --- OLLAMA FALLBACK INTERCEPTOR ---
+            # If native tool_calls is empty, check if it dumped JSON directly into content
+            if not getattr(msg, "tool_calls", None) and msg.content:
+                content_str = msg.content.strip()
+                try:
+                    # Strip markdown code blocks if the LLM wrapped it
+                    if content_str.startswith("```json"): 
+                        content_str = content_str[7:-3].strip()
+                    elif content_str.startswith("```"): 
+                        content_str = content_str[3:-3].strip()
+                    
+                    parsed_content = json.loads(content_str)
+                    if isinstance(parsed_content, dict) and "name" in parsed_content and "arguments" in parsed_content:
+                        logger.info("Intercepted inline JSON tool call. Normalizing.")
+                        # Fake the tool call structure so the rest of the loop understands it
+                        assistant_entry["tool_calls"] = [{
+                            "id": f"call_fallback_{turn}",
+                            "type": "function",
+                            "function": {
+                                "name": parsed_content["name"],
+                                "arguments": json.dumps(parsed_content["arguments"])
+                            }
+                        }]
+                        assistant_entry["content"] = "" # Blank out content to avoid confusing the context
+                except Exception:
+                    pass # Not JSON, just regular chatting
+            
+            # Native tool call handling
+            elif getattr(msg, "tool_calls", None):
+                assistant_entry["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        }
+                    } for tc in msg.tool_calls
+                ]
+            
+            self.history.append(assistant_entry)
+
+            # 2. Check for Tool Calls (Using our normalized entry!)
+            if "tool_calls" in assistant_entry:
+                for tool_call in assistant_entry["tool_calls"]:
+                    func_name = tool_call["function"]["name"]
+                    call_id = tool_call["id"]
+                    
                     try:
-                        args = json.loads(tool_call.function.arguments)
+                        args = json.loads(tool_call["function"]["arguments"])
                     except json.JSONDecodeError:
                         logger.error("LLM generated invalid JSON arguments")
                         self.history.append({
                             "role": "tool",
-                            "tool_call_id": tool_call.id,
+                            "tool_call_id": call_id,
                             "content": "ERROR: Invalid JSON arguments provided."
                         })
                         continue
@@ -232,7 +275,12 @@ PROTOCOL:
                         return
 
                     elif func_name == "execute_shell":
-                        output = self.shell.execute(args.get("command"))
+                        cmd = args.get("command")
+                        if not isinstance(cmd, str) or not cmd.strip():
+                            output = "ERROR: Missing or empty 'command' argument for execute_shell tool."
+                            logger.error(output)
+                        else:
+                            output = self.shell.execute(cmd)
                         
                         if self.debug_mode:
                             print(f"\n--- CMD OUT ---\n{output}\n---------------")
@@ -240,12 +288,12 @@ PROTOCOL:
                         # Feed result back to history
                         self.history.append({
                             "role": "tool",
-                            "tool_call_id": tool_call.id,
+                            "tool_call_id": call_id,
                             "content": output
                         })
             else:
                 # If LLM talks without tools, just push it back as user prompt to force action
-                content = msg.content or ""
+                content = assistant_entry.get("content") or ""
                 logger.warning(f"LLM replied without tools: {content[:50]}...")
                 self.history.append({
                     "role": "user", 

--- a/src/scribe.py
+++ b/src/scribe.py
@@ -192,7 +192,7 @@ async def main():
             await push_result(
                 args.redis_url, 
                 args.output_inbox, 
-                "TaskCompleted", 
+                "ScribeResult",
                 result_text,
                 meta=meta
             )


### PR DESCRIPTION
Closes #10 #2 


* roamer.py (Roamer / Investigator)

- Ollama API Compatibility Fix: Stripped the local/ prefix from the model string during initialization so requests route correctly to the local Ollama socket instead of 404ing.

- Inline JSON Tool Call Interceptor: Built a middleware patch in the execution loop to catch Ollama occasionally dumping raw JSON into msg.content. It normalizes the string into a standard tool_calls object, preventing infinite generation loops.


- Safe sudo Implementation: Added sudo, systemctl, and journalctl to the read-only whitelist. Modified the validation logic to shift its check to the second token if the first token is sudo (allowing sudo cat but blocking sudo rm).

- DRY Error Handling: Consolidated local and remote subprocess.run blocks under a single try/except to catch subprocess.TimeoutExpired and standard execution errors cleanly.

* guppi.py (GUPPI Daemon / Executive)

- Scribe Turn Tracking: Injected meta_dict = {"action_id": turn_id, "mode": mode} into the spawn_scribe subprocess call via the --meta flag. This ensures Scribe results can be perfectly mapped back to the specific Abe that requested them.


- Tool Help Dictionary Update: Added spawn_roamer to the _tool_help payload so agents know it exists. Updated spawn_scribe to clarify that GUPPI auto-routes the model based on the mode (removing the hallucination-prone model argument).

scribe.py (Scribe / Analyzer)

- Memory Ingester Collision Fix: Changed the final success payload event from "TaskCompleted" to "ScribeResult". This prevents GUPPI's background Tier-2 ingester from mistaking manual Abe reports for automated system summaries and deleting them from the inbox.