### PR TITLE
Make ntfy token optional in genesis.py and guppi.py

### DIFF
--- a/genesis.py
+++ b/genesis.py
@@ -101,7 +101,7 @@ def run_cmd(cmd, shell=False, check=True):
         sys.exit(1)
 
 def prompt(text, default=None):
-    if default:
+    if default is not None:
         val = input(f"{GREEN}[?]{RESET} {text} [{default}]: ").strip()
         return val if val else default
     else:

--- a/src/guppi.py
+++ b/src/guppi.py
@@ -117,7 +117,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger("guppi")
 
-if not NTFY_URL or not NTFY_TOKEN:
+if not NTFY_URL:
     logger.warning("NTFY not configured; human notifications disabled.")
     
 
@@ -1961,7 +1961,7 @@ You were asleep for: {time_str}
                 return
             
             elif tool in ("notify_human", "alert_human"):
-                if not NTFY_URL or not NTFY_TOKEN:
+                if not NTFY_URL:
                     result = {
                         "status": "skipped",
                         "reason": "ntfy_not_configured. Human may not be contactable. You might have to wait until they check in."
@@ -1970,7 +1970,9 @@ You were asleep for: {time_str}
                     msg = action.get("message", "")
                     prio = action.get("priority", "default")
                     kind = "ALERT" if tool == "alert_human" else "NOTIFY"
-                    headers = { "Priority": prio, "Authorization": f"Bearer {NTFY_TOKEN}" }
+                    headers = {"Priority": prio}
+                    if NTFY_TOKEN:
+                        headers["Authorization"] = f"Bearer {NTFY_TOKEN}"
 
                     try:
                         timeout = aiohttp.ClientTimeout(total=5)

--- a/src/heartbeat-monitor.py
+++ b/src/heartbeat-monitor.py
@@ -22,7 +22,7 @@ NTFY_URL = os.environ.get("NTFY_URL")
 
 # FAIL LOUD: No default token in code. Export NTFY_TOKEN in your shell/systemd.
 NTFY_TOKEN = os.environ.get("NTFY_TOKEN")
-NTFY_ENABLED = bool(NTFY_TOKEN and NTFY_URL)
+NTFY_ENABLED = bool(NTFY_URL)
 
 
 # TUNING
@@ -37,15 +37,17 @@ def send_alert(abe_name, last_seen_str):
 
     print(f"[!] FLATLINE: {abe_name} (Last seen: {last_seen_str})")
     try:
+        headers = {
+            "Title": f"Abe Down: {abe_name}",
+            "Priority": "urgent",
+            "Tags": "skull,rotating_light",
+        }
+        if NTFY_TOKEN:
+            headers["Authorization"] = f"Bearer {NTFY_TOKEN}"
         requests.post(
             NTFY_URL,
             data=f"🚑 FLATLINE DETECTED: {abe_name} has not reported in since {last_seen_str}.",
-            headers={
-                "Title": f"Abe Down: {abe_name}",
-                "Priority": "urgent",
-                "Tags": "skull,rotating_light",
-                "Authorization": f"Bearer {NTFY_TOKEN}"
-            },
+            headers=headers,
             timeout=5
         )
     except Exception as e:


### PR DESCRIPTION
- Fix prompt() to use `default is not None` so empty string default works
- Only warn/skip notifications when NTFY_URL is missing, not NTFY_TOKEN
- Only add Authorization header when NTFY_TOKEN is set

Closes #13 