### PR TITLE
Feat/downstream fixes features

### DIFF
--- a/src/guppi.py
+++ b/src/guppi.py
@@ -1088,18 +1088,6 @@ class GuppiDaemon:
                     logger.error(f"Failed to write stub: {e}")
             return # <--- EXIT without Thinking
         
-        # B0. Scribe Failure Detection (must check before generic maintenance gate)
-        event_type_b = norm["observed"].get("event_type", norm["observed"].get("event", ""))
-        if event_type_b == "ScribeFailed":
-            content_str = str(norm["observed"].get("content", ""))
-            source_file = meta.get("source_tier_1", "unknown")
-            await self.log_guppi_event(
-                "ScribeFailed",
-                f"Scribe failed for {source_file}: {content_str[:200]}",
-                source="GUPPI:Background"
-            )
-            return  # EXIT without Thinking
-
         # B. Silent Scribe / Background Tasks
         if meta.get("maintenance") is True:
             if meta.get("is_auto_prune"):
@@ -1147,7 +1135,17 @@ class GuppiDaemon:
                     logger.warning(f"Failed to clean up temp prompt file {prompt_file}: {e}")
             return # <--- EXIT without Thinking
 
-
+        # B2. Scribe Failure Detection
+        event_type_b = norm["observed"].get("event_type", norm["observed"].get("event", ""))
+        if event_type_b == "ScribeFailed":
+            content_str = str(norm["observed"].get("content", ""))
+            source_file = meta.get("source_tier_1", "unknown")
+            await self.log_guppi_event(
+                "ScribeFailed",
+                f"Scribe failed for {source_file}: {content_str[:200]}",
+                source="GUPPI:Background"
+            )
+            return  # EXIT without Thinking
         # 5. THINKING TRIGGER (The 7.2.3 Safety)
         # We pass norm["observed"] (The Envelope) so the LLM sees 'from', 'meta', and 'raw'.
         # GPT hates this because it's "messy", but it prevents context loss.
@@ -1696,9 +1694,11 @@ class GuppiDaemon:
 
     def _clean_json(self, text_response, thought_sig=None):
         try:
-            match = re.search(r'\{.*\}', text_response, re.DOTALL)
-            clean_json = match.group(0) if match else text_response
-            parsed = json.loads(clean_json)
+            content = text_response.strip()
+            match = re.search(r"```(?:json)?\s*(.*?)\s*```", content, re.DOTALL)
+            if match:
+                content = match.group(1).strip()
+            parsed = json.loads(content)
 
             # Guard: IF LLM sometimes returns a JSON array instead of an object
             if isinstance(parsed, list):

--- a/src/guppi.py
+++ b/src/guppi.py
@@ -1087,6 +1087,18 @@ class GuppiDaemon:
                 except Exception as e:
                     logger.error(f"Failed to write stub: {e}")
             return # <--- EXIT without Thinking
+        
+        # B0. Scribe Failure Detection (must check before generic maintenance gate)
+        event_type_b = norm["observed"].get("event_type", norm["observed"].get("event", ""))
+        if event_type_b == "ScribeFailed":
+            content_str = str(norm["observed"].get("content", ""))
+            source_file = meta.get("source_tier_1", "unknown")
+            await self.log_guppi_event(
+                "ScribeFailed",
+                f"Scribe failed for {source_file}: {content_str[:200]}",
+                source="GUPPI:Background"
+            )
+            return  # EXIT without Thinking
 
         # B. Silent Scribe / Background Tasks
         if meta.get("maintenance") is True:
@@ -1473,7 +1485,7 @@ class GuppiDaemon:
             event_type = event_data.get("event")
             is_chat = (event_type == "Chat")
             
-            if force_model:
+            if force_model is not None:
                 model = force_model
                 is_flash = (model == MODEL_FLASH)
             else:
@@ -1528,7 +1540,7 @@ class GuppiDaemon:
             tool = action.get("tool")
 
             # Implicit Escalation
-            if is_flash and tool in FLASH_FORBIDDEN_TOOLS:
+            if is_flash and tool in FLASH_FORBIDDEN_TOOLS and force_model is None:
                 logger.warning(f"ESCALATION: Flash attempted {tool}. Waking Pro.")
                 await self.log_guppi_event("EscalationTrigger", f"Denied Flash tool: {tool}")
 
@@ -1687,6 +1699,17 @@ class GuppiDaemon:
             match = re.search(r'\{.*\}', text_response, re.DOTALL)
             clean_json = match.group(0) if match else text_response
             parsed = json.loads(clean_json)
+
+            # Guard: IF LLM sometimes returns a JSON array instead of an object
+            if isinstance(parsed, list):
+                candidates = [
+                    x for x in parsed
+                    if isinstance(x, dict) and ("action" in x or "reasoning" in x)
+                ]
+                if len(candidates) == 1:
+                    parsed = candidates[0]
+                else:
+                    raise LLMOutputError("Ambiguous or invalid JSON array from LLM")
 
             # Active Decontamination
             keys_to_scrub = ["thought_signature", "thoughtSignature"]

--- a/src/roamer.py
+++ b/src/roamer.py
@@ -232,7 +232,12 @@ PROTOCOL:
                         return
 
                     elif func_name == "execute_shell":
-                        output = self.shell.execute(args.get("command"))
+                        cmd = args.get("command")
+                        if not isinstance(cmd, str) or not cmd.strip():
+                            output = "ERROR: Missing or empty 'command' argument for execute_shell tool."
+                            logger.error(output)
+                        else:
+                            output = self.shell.execute(cmd)
                         
                         if self.debug_mode:
                             print(f"\n--- CMD OUT ---\n{output}\n---------------")

--- a/src/roamer.py
+++ b/src/roamer.py
@@ -50,7 +50,7 @@ class SafeShell:
         "ls", "cat", "grep", "head", "tail", "find", 
         "stat", "df", "du", "whoami", "date", "echo", 
         "awk", "sed", "cut", "sort", "uniq", "wc", "uptime", "free",
-        "systemctl", "journalctl", "sudo"
+        "journalctl"
     ]
 
     FORBIDDEN_FLAGS = ["-i", "su"]
@@ -168,7 +168,7 @@ YOUR DIRECTIVE: {self.directive}
 
 TOOLS AVAILABLE:
 1. execute_shell: Run a shell command. 
-   - CONSTRAINTS: READ-ONLY. Allowed: ls, cat, grep, find, head, tail, df, du.
+   - CONSTRAINTS: READ-ONLY. Allowed: ls, cat, grep, find, head, tail, df, du, journalctl.
    - FORBIDDEN: rm, mv, cp, nano, vim, sed -i, > redirection, sudo.
    - If the user asks for a fix, INVESTIGATE first, then propose the fix in your final report. DO NOT execute it.
 
@@ -199,64 +199,70 @@ PROTOCOL:
                     temperature=0.1 # Low temp for precise logic
                 )
                 msg = response.choices[0].message
+                # Normalize assistant message into a plain dict for history so it doesn't crash turn 2
+                assistant_entry = {
+                    "role": msg.role,
+                    "content": msg.content,
+                }
+
+                # --- INLINE JSON FALLBACK INTERCEPTOR ---
+                if not getattr(msg, "tool_calls", None) and msg.content:
+                    content_str = msg.content.strip()
+                    try:
+                        # 1. Look for fenced JSON anywhere in the response
+                        match = re.search(r"```(?:json)?\s*(.*?)\s*```", content_str, re.DOTALL)
+                        if match:
+                            json_str = match.group(1).strip()
+                        else:
+                            # 2. Fallback: assume entire content is JSON
+                            json_str = content_str
+
+                        parsed_content = json.loads(json_str)
+
+                        if (
+                            isinstance(parsed_content, dict)
+                            and "name" in parsed_content
+                            and "arguments" in parsed_content
+                        ):
+                            logger.info("Intercepted inline JSON tool call. Normalizing.")
+
+                            assistant_entry["tool_calls"] = [{
+                                "id": f"call_fallback_{turn}",
+                                "type": "function",
+                                "function": {
+                                    "name": parsed_content["name"],
+                                    "arguments": json.dumps(parsed_content["arguments"])
+                                }
+                            }]
+
+                            # Avoid double signal in context
+                            assistant_entry["content"] = ""
+
+                    except Exception as e:
+                        logger.debug(f"Inline JSON parse failed: {e}")
+                # Native tool call handling
+                elif getattr(msg, "tool_calls", None):
+                    assistant_entry["tool_calls"] = [
+                        {
+                            "id": tc.id,
+                            "type": tc.type,
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            }
+                        } for tc in msg.tool_calls
+                    ]
+                self.history.append(assistant_entry)
             except Exception as e:
                 self._report_failure(f"LLM API Failure: {e}")
                 return
 
-            # Normalize assistant message into a plain dict for history
-            assistant_entry = {
-                "role": msg.role,
-                "content": msg.content,
-            }
-            
-            # --- OLLAMA FALLBACK INTERCEPTOR ---
-            # If native tool_calls is empty, check if it dumped JSON directly into content
-            if not getattr(msg, "tool_calls", None) and msg.content:
-                content_str = msg.content.strip()
-                try:
-                    # Strip markdown code blocks if the LLM wrapped it
-                    if content_str.startswith("```json"): 
-                        content_str = content_str[7:-3].strip()
-                    elif content_str.startswith("```"): 
-                        content_str = content_str[3:-3].strip()
-                    
-                    parsed_content = json.loads(content_str)
-                    if isinstance(parsed_content, dict) and "name" in parsed_content and "arguments" in parsed_content:
-                        logger.info("Intercepted inline JSON tool call. Normalizing.")
-                        # Fake the tool call structure so the rest of the loop understands it
-                        assistant_entry["tool_calls"] = [{
-                            "id": f"call_fallback_{turn}",
-                            "type": "function",
-                            "function": {
-                                "name": parsed_content["name"],
-                                "arguments": json.dumps(parsed_content["arguments"])
-                            }
-                        }]
-                        assistant_entry["content"] = "" # Blank out content to avoid confusing the context
-                except Exception:
-                    pass # Not JSON, just regular chatting
-            
-            # Native tool call handling
-            elif getattr(msg, "tool_calls", None):
-                assistant_entry["tool_calls"] = [
-                    {
-                        "id": tc.id,
-                        "type": tc.type,
-                        "function": {
-                            "name": tc.function.name,
-                            "arguments": tc.function.arguments,
-                        }
-                    } for tc in msg.tool_calls
-                ]
-            
-            self.history.append(assistant_entry)
-
-            # 2. Check for Tool Calls (Using our normalized entry!)
+            # 2. Check for Tool Calls (Using normalized entry)
             if "tool_calls" in assistant_entry:
                 for tool_call in assistant_entry["tool_calls"]:
                     func_name = tool_call["function"]["name"]
                     call_id = tool_call["id"]
-                    
+
                     try:
                         args = json.loads(tool_call["function"]["arguments"])
                     except json.JSONDecodeError:
@@ -276,12 +282,13 @@ PROTOCOL:
 
                     elif func_name == "execute_shell":
                         cmd = args.get("command")
+
                         if not isinstance(cmd, str) or not cmd.strip():
                             output = "ERROR: Missing or empty 'command' argument for execute_shell tool."
                             logger.error(output)
                         else:
                             output = self.shell.execute(cmd)
-                        
+
                         if self.debug_mode:
                             print(f"\n--- CMD OUT ---\n{output}\n---------------")
 
@@ -289,14 +296,16 @@ PROTOCOL:
                         self.history.append({
                             "role": "tool",
                             "tool_call_id": call_id,
+                            "tool_call_id": call_id,
                             "content": output
                         })
+
             else:
                 # If LLM talks without tools, just push it back as user prompt to force action
                 content = assistant_entry.get("content") or ""
                 logger.warning(f"LLM replied without tools: {content[:50]}...")
                 self.history.append({
-                    "role": "user", 
+                    "role": "user",
                     "content": "You must use a tool to proceed (execute_shell) or end the session (finish_investigation)."
                 })
 

--- a/src/roamer.py
+++ b/src/roamer.py
@@ -179,7 +179,7 @@ PROTOCOL:
 - You are in a loop. You observe -> think -> act.
 - Do not hallucinate file contents. cat them.
 - Do not guess paths. ls them.
-- If you hit "Permission denied", report it; do not try to sudo.
+- If you hit "Permission denied" for any WRITE task, report it; do not try to sudo. You can sudo any read task.
 - Keep your turns efficient.
 """
 
@@ -226,12 +226,15 @@ PROTOCOL:
                         ):
                             logger.info("Intercepted inline JSON tool call. Normalizing.")
 
+                            args = parsed_content["arguments"]
+                            args_str = args if isinstance(args, str) else json.dumps(args)
+
                             assistant_entry["tool_calls"] = [{
                                 "id": f"call_fallback_{turn}",
                                 "type": "function",
                                 "function": {
                                     "name": parsed_content["name"],
-                                    "arguments": json.dumps(parsed_content["arguments"])
+                                    "arguments": args_str
                                 }
                             }]
 

--- a/src/roamer.py
+++ b/src/roamer.py
@@ -169,7 +169,7 @@ YOUR DIRECTIVE: {self.directive}
 TOOLS AVAILABLE:
 1. execute_shell: Run a shell command. 
    - CONSTRAINTS: READ-ONLY. Allowed: ls, cat, grep, find, head, tail, df, du, journalctl.
-   - FORBIDDEN: rm, mv, cp, nano, vim, sed -i, > redirection, sudo.
+   - FORBIDDEN: rm, mv, cp, nano, vim, sed -i, > redirection, sudo(allowed with limits).
    - If the user asks for a fix, INVESTIGATE first, then propose the fix in your final report. DO NOT execute it.
 
 2. finish_investigation: Call this when you have found the answer or failed.
@@ -295,7 +295,6 @@ PROTOCOL:
                         # Feed result back to history
                         self.history.append({
                             "role": "tool",
-                            "tool_call_id": call_id,
                             "tool_call_id": call_id,
                             "content": output
                         })

--- a/src/scribe.py
+++ b/src/scribe.py
@@ -113,7 +113,7 @@ async def run_llm_generation(model_name: str, prompt_text: str) -> str:
 
     async with aiohttp.ClientSession() as session:
         # Bumped timeout to 1200s (20 mins) specifically to account for Nanbeige's deep thinking
-        async with session.post(url, headers=headers, json=payload, timeout=1200) as resp:
+        async with session.post(url, headers=headers, json=payload, timeout=aiohttp.ClientTimeout(total=1200)) as resp:
             if resp.status != 200:
                 err = await resp.text()
                 raise Exception(f"API Error {resp.status}: {err}")
@@ -192,7 +192,7 @@ async def main():
             await push_result(
                 args.redis_url, 
                 args.output_inbox, 
-                "TaskCompleted", 
+                "ScribeResult", 
                 result_text,
                 meta=meta
             )


### PR DESCRIPTION
- Handle cases where model returns `[ {...} ]` instead of `{...}`  (unwrap if there's a single valid object, otherwise fail)

- Fix escalation bug:
  `if force_model:` -> `if force_model is not None`  and don't re-escalate if we're already forced to Pro

- Catch `ScribeFailed` early and just log + exit  instead of letting it go through the think cycle

- Make sure `ScribeResult` is classified properly

Thank you @vipervire for most of these changes.