### PR TITLE
tighten public repository hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,12 @@ venv/
 
 # Runtime artifacts
 .env
+.env.*
 *.log
 *.db
 *.sqlite
 *.sqlite3
+pr_diff*.txt
 
 # OS / Editor
 .DS_Store

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,6 +1,6 @@
 LLM_PROVIDER=openai_compat
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_API_KEY=sk-or-v1-example-replace-me
+OPENAI_API_KEY=your-openrouter-api-key
 
 MODEL_FLASH=local/gemma-4-26B-it
 MODEL_PRO=local/Qwen3.5-27B

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,6 +1,6 @@
 LLM_PROVIDER=openai_compat
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_API_KEY=sk-or-v1-dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+OPENAI_API_KEY=sk-or-v1-example-replace-me
 
 MODEL_FLASH=local/gemma-4-26B-it
 MODEL_PRO=local/Qwen3.5-27B
@@ -9,19 +9,19 @@ MODEL_ROAMER=local/gemma-4-26B-it
 MODEL_SUMMARIZE=local/mistral
 # --- Local Fleet Endpoints ---
 # Endpoints Guppi uses to route specific roles when a model string starts with "local/"
-PRO_API_URL=http://10.0.0.99:8080/v1 
-FLASH_API_URL=http://10.0.0.99:8080/v1
-SCRIBE_API_URL=http://10.0.0.99:8080/v1
-ROAMER_API_URL=http://10.0.0.99:8080/v1
-SUMMARIZE_API_URL=http://10.0.0.99:8080/v1
+PRO_API_URL=http://127.0.0.1:8080/v1
+FLASH_API_URL=http://127.0.0.1:8080/v1
+SCRIBE_API_URL=http://127.0.0.1:8080/v1
+ROAMER_API_URL=http://127.0.0.1:8080/v1
+SUMMARIZE_API_URL=http://127.0.0.1:8080/v1
 
 # --- Infrastructure ---
-REDIS_HOST=10.0.0.99
+REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
-REDIS_PASSWORD=volition #default 
-REDIS_URL=redis://:volition@10.0.0.99:6379/0
+REDIS_PASSWORD=change-me
+REDIS_URL=redis://:change-me@127.0.0.1:6379/0
 NTFY_URL=https://ntfy.ntfy.url/ntfy_topic
-NTFY_TOKEN=tk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NTFY_TOKEN=ntfy-token-example
 SEARXNG_URL=https://civitat.es/search
 
 # Leave this as is if you want to use openrouter and would like me to 'track' how many people are using Volition


### PR DESCRIPTION
## Summary
- Correct the tracked `.gitingore` filename to `.gitignore`.
- Ignore environment files, Python artifacts, logs, databases, and local diff artifacts.
- Replace private-looking environment examples with safe placeholders.

## Impact
Local credentials and generated runtime files are less likely to be committed accidentally.

## Validation
- `git diff --check`
- Staged credential and private-path scan

## AI disclosure
This PR is derived from custom code and repository work originally authored by Abe in the private, local Abiverse repository. Codex was used to replicate, sanitize, organize, and validate the changes for the public Volition repository.